### PR TITLE
Fix auto.include.git.dirs handling on Windows

### DIFF
--- a/plugin/src/main/java/me/champeau/gradle/igp/internal/DefaultIncludeGitExtension.java
+++ b/plugin/src/main/java/me/champeau/gradle/igp/internal/DefaultIncludeGitExtension.java
@@ -96,7 +96,7 @@ public abstract class DefaultIncludeGitExtension implements GitIncludeExtension 
         autoGitDirs = forUseAtConfigurationTime(providers.gradleProperty(AUTO_GIT_DIRS));
         Map<String, List<File>> autoDirs = Collections.emptyMap();
         if (autoGitDirs.isPresent()) {
-            autoDirs = Arrays.stream(autoGitDirs.get().split("[,;:](\\s)?"))
+            autoDirs = Arrays.stream(autoGitDirs.get().split("[,;](\\s)?"))
                     .map(File::new)
                     .flatMap(dir ->
                             Arrays.stream(dir.listFiles())


### PR DESCRIPTION
Splitting auto.include.git.dirs value on ':' breaks on Windows because colon is used as drive letter separator.
For example
`auto.include.git.dirs=C:/home/me/development/gradle`
will throw an exception.

In the documentation only ',' is mentioned as separator. You might consider to also remove ';' from the splitter regex.