### PR TITLE
Fix include directory relative path

### DIFF
--- a/plugin/src/main/java/me/champeau/gradle/igp/internal/DefaultIncludedGitRepo.java
+++ b/plugin/src/main/java/me/champeau/gradle/igp/internal/DefaultIncludedGitRepo.java
@@ -92,7 +92,7 @@ public abstract class DefaultIncludedGitRepo implements IncludedGitRepo {
             for (IncludedBuild include : includes) {
                 // unchecked cast because of inconsistency in Gradle API
                 //noinspection unchecked
-                settings.includeBuild(getCheckoutDirectory().dir(include.directory), (Action<ConfigurableIncludedBuild>) include.spec);
+                settings.includeBuild(new File(checkoutDirectory, include.directory), (Action<ConfigurableIncludedBuild>) include.spec);
             }
         }
     }


### PR DESCRIPTION
This commit fixes the inclusion path, in case the includeBuild
call is done on a repository which isn't found in the checkouts
directory (e.g when using the automatic mapping from a local
directory).