### PR TITLE
feat: Add support for encrypted ssh keys

### DIFF
--- a/docs/src/docs/asciidoc/index.adoc
+++ b/docs/src/docs/asciidoc/index.adoc
@@ -236,6 +236,7 @@ gitRepositories {
             // or
             sshWithPublicKey {
                 privateKey = file("/path/to/private/key")
+                // Leave this out if your key file is not encrypted.
                 passphrase = '...'
             }
             // or
@@ -262,6 +263,7 @@ gitRepositories {
             // or
             sshWithPublicKey {
                 privateKey.set(file("/path/to/private/key"))
+                // Leave this out if your key file is not encrypted.
                 passphrase.set("...")
             }
             // or

--- a/docs/src/docs/asciidoc/index.adoc
+++ b/docs/src/docs/asciidoc/index.adoc
@@ -215,7 +215,7 @@ NOTE: You may use several `includeBuild` statements from a single repository.
 The plugin supports 3 different authentication mechanisms:
 
 - basic authentication (username + password)
-- ssh with public key
+- ssh with public key (plaintext or encrypted)
 - ssh with password
 
 Authentication can be configured per repository:
@@ -236,6 +236,7 @@ gitRepositories {
             // or
             sshWithPublicKey {
                 privateKey = file("/path/to/private/key")
+                passphrase = '...'
             }
             // or
             sshWithPassword {
@@ -261,6 +262,7 @@ gitRepositories {
             // or
             sshWithPublicKey {
                 privateKey.set(file("/path/to/private/key"))
+                passphrase.set("...")
             }
             // or
             sshWithPassword {

--- a/plugin/src/main/java/me/champeau/gradle/igp/Authentication.java
+++ b/plugin/src/main/java/me/champeau/gradle/igp/Authentication.java
@@ -43,18 +43,11 @@ public interface Authentication {
 
     /**
      * Configures SSH with a public key, allowing configuration
-     * of the private key location.
+     * of the private key location, as well as an encryption
+     * passphrase if the key is encrypted.
      * @param spec the key configuration
      */
     void sshWithPublicKey(Action<? super KeyConfiguration> spec);
-
-    /**
-     * Configures SSH with an encrypted public key, allowing configuration
-     * of the private key location as well as a string to use as the passphrase.
-     * @param spec the key configuration
-     */
-    void sshWithEncryptedPublicKey(Action<? super EncryptedKeyConfiguration> spec);
-
 
     /**
      * Configures SSH with password authentication.
@@ -88,12 +81,6 @@ public interface Authentication {
      */
     interface KeyConfiguration {
         RegularFileProperty getPrivateKey();
-    }
-
-    /**
-     * Represents an encrypted key configuration.
-     */
-    interface EncryptedKeyConfiguration extends KeyConfiguration {
         Property<String> getPassphrase();
     }
 }

--- a/plugin/src/main/java/me/champeau/gradle/igp/Authentication.java
+++ b/plugin/src/main/java/me/champeau/gradle/igp/Authentication.java
@@ -49,6 +49,14 @@ public interface Authentication {
     void sshWithPublicKey(Action<? super KeyConfiguration> spec);
 
     /**
+     * Configures SSH with an encrypted public key, allowing configuration
+     * of the private key location as well as a string to use as the passphrase.
+     * @param spec the key configuration
+     */
+    void sshWithEncryptedPublicKey(Action<? super EncryptedKeyConfiguration> spec);
+
+
+    /**
      * Configures SSH with password authentication.
      * @param spec the configuration
      */
@@ -80,5 +88,12 @@ public interface Authentication {
      */
     interface KeyConfiguration {
         RegularFileProperty getPrivateKey();
+    }
+
+    /**
+     * Represents an encrypted key configuration.
+     */
+    interface EncryptedKeyConfiguration extends KeyConfiguration {
+        Property<String> getPassphrase();
     }
 }

--- a/plugin/src/main/java/me/champeau/gradle/igp/internal/DefaultAuthentication.java
+++ b/plugin/src/main/java/me/champeau/gradle/igp/internal/DefaultAuthentication.java
@@ -57,13 +57,6 @@ public class DefaultAuthentication implements Authentication {
     }
 
     @Override
-    public void sshWithEncryptedPublicKey(Action<? super EncryptedKeyConfiguration> spec) {
-        none();
-        keyConfiguration = objects.newInstance(EncryptedKeyConfiguration.class);
-        spec.execute((EncryptedKeyConfiguration) keyConfiguration);
-    }
-
-    @Override
     public void sshWithPassword(Action<? super WithPassword> spec) {
         none();
         sshWithPassword = objects.newInstance(WithPassword.class);
@@ -72,15 +65,6 @@ public class DefaultAuthentication implements Authentication {
 
     Optional<KeyConfiguration> getSshWithPublicKey() {
         return Optional.ofNullable(keyConfiguration);
-    }
-
-    Optional<EncryptedKeyConfiguration> getSshWithEncryptedPublicKey() {
-        // instanceof acts as a nullcheck as well here
-        if (keyConfiguration instanceof EncryptedKeyConfiguration) {
-            return Optional.of((EncryptedKeyConfiguration) keyConfiguration);
-        } else {
-            return Optional.empty();
-        }
     }
 
     Optional<BasicAuth> getBasicAuth() {

--- a/plugin/src/main/java/me/champeau/gradle/igp/internal/DefaultAuthentication.java
+++ b/plugin/src/main/java/me/champeau/gradle/igp/internal/DefaultAuthentication.java
@@ -57,6 +57,13 @@ public class DefaultAuthentication implements Authentication {
     }
 
     @Override
+    public void sshWithEncryptedPublicKey(Action<? super EncryptedKeyConfiguration> spec) {
+        none();
+        keyConfiguration = objects.newInstance(EncryptedKeyConfiguration.class);
+        spec.execute((EncryptedKeyConfiguration) keyConfiguration);
+    }
+
+    @Override
     public void sshWithPassword(Action<? super WithPassword> spec) {
         none();
         sshWithPassword = objects.newInstance(WithPassword.class);
@@ -65,6 +72,14 @@ public class DefaultAuthentication implements Authentication {
 
     Optional<KeyConfiguration> getSshWithPublicKey() {
         return Optional.ofNullable(keyConfiguration);
+    }
+
+    Optional<EncryptedKeyConfiguration> getSshWithEncryptedPublicKey() {
+        if (keyConfiguration instanceof EncryptedKeyConfiguration) {
+            return Optional.of((EncryptedKeyConfiguration) keyConfiguration);
+        } else {
+            return Optional.empty();
+        }
     }
 
     Optional<BasicAuth> getBasicAuth() {

--- a/plugin/src/main/java/me/champeau/gradle/igp/internal/DefaultAuthentication.java
+++ b/plugin/src/main/java/me/champeau/gradle/igp/internal/DefaultAuthentication.java
@@ -75,6 +75,7 @@ public class DefaultAuthentication implements Authentication {
     }
 
     Optional<EncryptedKeyConfiguration> getSshWithEncryptedPublicKey() {
+        // instanceof acts as a nullcheck as well here
         if (keyConfiguration instanceof EncryptedKeyConfiguration) {
             return Optional.of((EncryptedKeyConfiguration) keyConfiguration);
         } else {

--- a/plugin/src/main/java/me/champeau/gradle/igp/internal/DefaultIncludeGitExtension.java
+++ b/plugin/src/main/java/me/champeau/gradle/igp/internal/DefaultIncludeGitExtension.java
@@ -26,37 +26,20 @@ import org.eclipse.jgit.api.GitCommand;
 import org.eclipse.jgit.api.TransportCommand;
 import org.eclipse.jgit.api.errors.GitAPIException;
 import org.eclipse.jgit.lib.Ref;
-import org.eclipse.jgit.transport.JschConfigSessionFactory;
-import org.eclipse.jgit.transport.OpenSshConfig;
-import org.eclipse.jgit.transport.SshSessionFactory;
-import org.eclipse.jgit.transport.SshTransport;
-import org.eclipse.jgit.transport.UsernamePasswordCredentialsProvider;
+import org.eclipse.jgit.transport.*;
 import org.eclipse.jgit.util.FS;
 import org.gradle.api.Action;
 import org.gradle.api.GradleException;
-import org.gradle.api.file.RegularFile;
-import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.initialization.Settings;
 import org.gradle.api.model.ObjectFactory;
-import org.gradle.api.provider.Property;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.provider.ProviderFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.inject.Inject;
-import java.io.DataInputStream;
-import java.io.DataOutputStream;
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
+import java.io.*;
+import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -229,25 +212,11 @@ public abstract class DefaultIncludeGitExtension implements GitIncludeExtension 
                 protected JSch createDefaultJSch(FS fs) throws JSchException {
                     JSch defaultJSch = super.createDefaultJSch( fs );
                     if (keyConfig.getPrivateKey().isPresent()) {
-                        defaultJSch.addIdentity(keyConfig.getPrivateKey().get().getAsFile().getAbsolutePath());
-                    }
-                    return defaultJSch;
-                }
-            };
-            command.setTransportConfigCallback(transport -> {
-                SshTransport sshTransport = (SshTransport) transport;
-                sshTransport.setSshSessionFactory(sshSessionFactory);
-            });
-        });
-        authentication.getSshWithEncryptedPublicKey().ifPresent(keyConfig -> {
-            SshSessionFactory sshSessionFactory = new JschConfigSessionFactory() {
-                @Override
-                protected JSch createDefaultJSch(FS fs) throws JSchException {
-                    JSch defaultJSch = super.createDefaultJSch( fs );
-                    RegularFile pKey = keyConfig.getPrivateKey().getOrNull();
-                    String keyPassphrase = keyConfig.getPassphrase().getOrNull();
-                    if (pKey != null && keyPassphrase != null) {
-                        defaultJSch.addIdentity(pKey.getAsFile().getAbsolutePath(), keyPassphrase);
+                        defaultJSch.addIdentity(
+                                keyConfig.getPrivateKey().get().getAsFile().getAbsolutePath(),
+                                // passing null here will do the same thing as the single argument override.
+                                keyConfig.getPassphrase().getOrNull()
+                        );
                     }
                     return defaultJSch;
                 }

--- a/plugin/src/main/java/me/champeau/gradle/igp/internal/DefaultIncludeGitExtension.java
+++ b/plugin/src/main/java/me/champeau/gradle/igp/internal/DefaultIncludeGitExtension.java
@@ -214,7 +214,7 @@ public abstract class DefaultIncludeGitExtension implements GitIncludeExtension 
                     if (keyConfig.getPrivateKey().isPresent()) {
                         defaultJSch.addIdentity(
                                 keyConfig.getPrivateKey().get().getAsFile().getAbsolutePath(),
-                                // passing null here will do the same thing as the single argument override.
+                                // passing null here will do the same thing as the single argument overload.
                                 keyConfig.getPassphrase().getOrNull()
                         );
                     }


### PR DESCRIPTION
I noticed there's no way to use an encrypted key file for ssh authentication in the plugin, so I tried adding it in. I'm not sure how to test it, but it looked straightforward enough...