### PR TITLE
Upgrade JGit to 6.3.0 (needs Java 11).

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-jgit = "5.13.0.202109080827-r"
+jgit = "6.3.0.202209071007-r"
 spock = "2.0-groovy-3.0"
 groovy = "3.0.9"
 

--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -13,7 +13,7 @@ group = "me.champeau.gradle.includegit"
 
 java {
     toolchain {
-        languageVersion.set(JavaLanguageVersion.of(8))
+        languageVersion.set(JavaLanguageVersion.of(11))
     }
 }
 

--- a/plugin/src/main/java/me/champeau/gradle/igp/internal/DefaultIncludeGitExtension.java
+++ b/plugin/src/main/java/me/champeau/gradle/igp/internal/DefaultIncludeGitExtension.java
@@ -15,22 +15,24 @@
  */
 package me.champeau.gradle.igp.internal;
 
-import com.jcraft.jsch.JSch;
-import com.jcraft.jsch.JSchException;
-import com.jcraft.jsch.Session;
 import me.champeau.gradle.igp.Authentication;
 import me.champeau.gradle.igp.GitIncludeExtension;
 import me.champeau.gradle.igp.IncludedGitRepo;
+
+import com.jcraft.jsch.JSch;
+import com.jcraft.jsch.JSchException;
+import com.jcraft.jsch.Session;
+
 import org.eclipse.jgit.api.Git;
 import org.eclipse.jgit.api.GitCommand;
 import org.eclipse.jgit.api.TransportCommand;
 import org.eclipse.jgit.api.errors.GitAPIException;
 import org.eclipse.jgit.lib.Ref;
-import org.eclipse.jgit.transport.JschConfigSessionFactory;
-import org.eclipse.jgit.transport.OpenSshConfig;
 import org.eclipse.jgit.transport.SshSessionFactory;
 import org.eclipse.jgit.transport.SshTransport;
 import org.eclipse.jgit.transport.UsernamePasswordCredentialsProvider;
+import org.eclipse.jgit.transport.ssh.jsch.JschConfigSessionFactory;
+import org.eclipse.jgit.transport.ssh.jsch.OpenSshConfig;
 import org.eclipse.jgit.util.FS;
 import org.gradle.api.Action;
 import org.gradle.api.GradleException;


### PR DESCRIPTION
See https://projects.eclipse.org/projects/technology.jgit/releases/6.3.0/.

Upgrading to Java 11 might introduce issues (see https://github.com/melix/includegit-gradle-plugin/issues/13#issuecomment-1321872779), but IMO it is counterbalanced with all fixes and new features that JGit 6.3.0 is coming with.