### PR TITLE
Add a `codeReady` event

### DIFF
--- a/docs/src/docs/asciidoc/index.adoc
+++ b/docs/src/docs/asciidoc/index.adoc
@@ -362,8 +362,8 @@ gitRepositories {
 gitRepositories {
     include("my-project") {
         // ...
-        codeReady { event ->
-            println("Project cloned in ${event.checkoutDirectory}")
+        codeReady {
+            println("Project cloned in ${checkoutDirectory}")
         }
     }
 }

--- a/docs/src/docs/asciidoc/index.adoc
+++ b/docs/src/docs/asciidoc/index.adoc
@@ -336,6 +336,40 @@ gitRepositories {
 }
 ----
 
+== Performing actions before the build is included
+
+It is possible to perform actions right after a project has been cloned and before it is included.
+This can be useful, for example, if the project needs to be analyzed in order to properly configure the included builds.
+
+The action will always be called, even if sources are already available locally.
+It is **not** recommended to mutate sources as part of this callback, since this will likely break updating the sources later.
+
+.Executing code before the build is included
+[source,groovy,role="multi-language-sample",subs="attributes+"]
+----
+gitRepositories {
+    include('my-project') {
+    // ...
+        codeReady { event ->
+            println("Project cloned in ${event.checkoutDirectory}")
+        }
+    }
+}
+----
+
+[source,kotlin,role="multi-language-sample",subs="attributes+"]
+----
+gitRepositories {
+    include("my-project") {
+        // ...
+        codeReady { event ->
+            println("Project cloned in ${event.checkoutDirectory}")
+        }
+    }
+}
+----
+
+
 [[comparison]]
 == Comparison of solutions
 

--- a/plugin/src/functionalTest/groovy/me/champeau/gradle/igp/BasicFunctionalTest.groovy
+++ b/plugin/src/functionalTest/groovy/me/champeau/gradle/igp/BasicFunctionalTest.groovy
@@ -23,6 +23,8 @@ class BasicFunctionalTest extends AbstractFunctionalTest {
 \\--- com.acme.somelib:somelib1:0.0 -> project :testlib0
 '''
 
+        outputContains 'Code ready'
+
         where:
         useCommit << [false, true]
     }

--- a/plugin/src/main/java/me/champeau/gradle/igp/IncludedGitRepo.java
+++ b/plugin/src/main/java/me/champeau/gradle/igp/IncludedGitRepo.java
@@ -21,6 +21,8 @@ import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.initialization.ConfigurableIncludedBuild;
 import org.gradle.api.provider.Property;
 
+import java.io.File;
+
 /**
  * Configures an included Git repository.
  */
@@ -94,4 +96,35 @@ public interface IncludedGitRepo extends Named {
      * @param config the authentication configuration
      */
     void authentication(Action<? super Authentication> config);
+
+    /**
+     * Allows executing some code right after a repository has been checked out, typically
+     * before the directory is included in a composite build.
+     * @param configuration the configuration action
+     */
+    void codeReady(Action<? super CodeReadyEvent> configuration);
+
+    /**
+     * Base interface for events.
+     */
+    interface Event {
+        /**
+         * The git repository for which the event was called
+         * @return the git repository
+         */
+        IncludedGitRepo getIncludedGitRepo();
+    }
+
+    /**
+     * Event triggered when the code of an included repository
+     * is ready (e.g checked out). It is _not_ recommended to alter
+     * the contents of the directory as it will likely break updates.
+     */
+    interface CodeReadyEvent extends Event {
+        /**
+         * The directory where the project is checked out.
+         * @return the directory
+         */
+        File getCheckoutDirectory();
+    }
 }

--- a/samples/basic/groovy/settings.gradle
+++ b/samples/basic/groovy/settings.gradle
@@ -17,5 +17,9 @@ gitRepositories {
         if (gradle.startParameter.projectProperties.containsKey('checkoutDir')) {
             checkoutDirectory.set(file(gradle.startParameter.projectProperties.get('checkoutDir')))
         }
+        codeReady { event ->
+            println "Code ready"
+            println "Checkout directory: ${event.checkoutDirectory}"
+        }
     }
 }

--- a/samples/basic/kotlin/settings.gradle.kts
+++ b/samples/basic/kotlin/settings.gradle.kts
@@ -20,5 +20,9 @@ gitRepositories {
         if (gradle.startParameter.projectProperties.containsKey("checkoutDir")) {
             checkoutDirectory.set(file(gradle.startParameter.projectProperties.get("checkoutDir")!!))
         }
+        codeReady { event ->
+            println "Code ready"
+            println "Checkout directory: ${event.checkoutDirectory}"
+        }
     }
 }

--- a/samples/basic/kotlin/settings.gradle.kts
+++ b/samples/basic/kotlin/settings.gradle.kts
@@ -20,9 +20,9 @@ gitRepositories {
         if (gradle.startParameter.projectProperties.containsKey("checkoutDir")) {
             checkoutDirectory.set(file(gradle.startParameter.projectProperties.get("checkoutDir")!!))
         }
-        codeReady { event ->
-            println "Code ready"
-            println "Checkout directory: ${event.checkoutDirectory}"
+        codeReady {
+            println("Code ready")
+            println("Checkout directory: ${checkoutDirectory}")
         }
     }
 }


### PR DESCRIPTION
This event gives the opportunity to the user to perform actions after sources have been cloned, and before the project is actually included. For example, this can be used to analyze the checked out sources, in order to perform configuration of the included build.