### PR TITLE
Improve error-handling for git cli client.

### DIFF
--- a/plugin/src/main/java/me/champeau/gradle/igp/internal/git/cli/ExecOpsHelper.java
+++ b/plugin/src/main/java/me/champeau/gradle/igp/internal/git/cli/ExecOpsHelper.java
@@ -31,7 +31,7 @@ class ExecOpsHelper {
 
     void assertNormalExitValue() {
       if (exitCode != 0) {
-        throw new IllegalStateException(String.format("Command failed with exit code %d: %s", exitCode, stdErr));
+        throw new IllegalStateException(String.format("Command failed with exit code %d: %s", exitCode, stdErr.get()));
       }
     }
   }


### PR DESCRIPTION
1. fix: call get() on Provider<String> for error-reporting.
2. Ignore exit value and assert normal exit value for all exec ops. This improves the user experience with more useful error messages.

Example of old error report:
```
An exception occurred applying plugin request [id: 'cash.server.include-misk', version: '1.337.2']
> Failed to apply plugin 'cash.server.include-misk'.
   > Unable to clone repository contents: Process 'command 'git'' finished with non-zero exit value 1
```

and new error report with these changes:
```
* What went wrong:
An exception occurred applying plugin request [id: 'cash.server.settings', version: '1.338.0']
> Failed to apply plugin class 'com.squareup.cash.server.includemisk.IncludeMiskPlugin'.
   > Unable to clone repository contents: Command failed with exit code 1: error: pathspec 'aparajon:armand/09.25.25-update-shard-targetting-logic' did not match any file(s) known to git
```